### PR TITLE
Add verify_SSL=>1 to HTTP::Tiny to verify https server identity

### DIFF
--- a/lib/CloudHealth/API/Caller.pm
+++ b/lib/CloudHealth/API/Caller.pm
@@ -5,6 +5,7 @@ package CloudHealth::API::Caller;
 
   has ua => (is => 'ro', default => sub {
     HTTP::Tiny->new(
+      verify_SSL => 1,
       agent => 'CloudHealth::API Perl Client ' . $CloudHealth::API::VERSION,
     );
   });


### PR DESCRIPTION
The `verify_SSL=>1` flag is missing from HTTP::Tiny, and could allow a network attacker to MITM https connections made by this distribution.

I don't have a CloudHealth API key, so unable to verify or test.

For more context see: https://hackeriet.github.io/cpan-http-tiny-overview/